### PR TITLE
Update Concave.sol - Reserves the 200 NFTs for Colors holders

### DIFF
--- a/contracts/Concave.sol
+++ b/contracts/Concave.sol
@@ -54,7 +54,7 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
         } else {
             require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder");
             uint256 validMintAmount = 0;
-            for (uint i = 0; i <= requiredNFT.balanceOf(msg.sender); i++) {
+            for (uint i = 0; i < requiredNFT.balanceOf(msg.sender); i++) {
                 uint256 claimTokenId = requiredNFT.tokenOfOwnerByIndex(msg.sender, i);
                 if (hasClaimed[claimTokenId] < 2) {
                     validMintAmount += 2 - hasClaimed[claimTokenId];

--- a/contracts/Concave.sol
+++ b/contracts/Concave.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "hardhat/console.sol";
+import './colors/INFTOwner.sol';
 
 contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
     using Strings for uint256;
@@ -19,10 +20,16 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
     uint256 public maxMintAmount = 10;
     uint256 public price = 0.03 ether;
     bool public revealed = false;
+<<<<<<< Updated upstream
     bool public presaleActive = true;
     ERC721Enumerable public requiredNFT = ERC721Enumerable(0x9fdb31F8CE3cB8400C7cCb2299492F2A498330a4);
 
     mapping(uint256 => uint256) public hasClaimed;
+=======
+    mapping (address => uint256) public hasMinted;
+
+    address public THE_COLORS = address(0x9fdb31F8CE3cB8400C7cCb2299492F2A498330a4);
+>>>>>>> Stashed changes
 
     constructor(
         string memory _name,
@@ -52,6 +59,7 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
         if (totalSupply() > 200 || !presaleActive) {
             require(msg.value >= price*_mintAmount, "insufficient funds");
         } else {
+<<<<<<< Updated upstream
             require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder");
             uint256 validMintAmount = 0;
             for (uint i = 0; i < requiredNFT.balanceOf(msg.sender); i++) {
@@ -63,11 +71,17 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
             }
             require(validMintAmount > 0, "no valid NFTs left to claim with");
             require(_mintAmount <= validMintAmount, "msg.sender exceeding the maximum cap of free mint");
+=======
+            if(INFTOwner(THE_COLORS).balanceOf(msg.sender) < 1 || hasMinted[msg.sender] > 2 * INFTOwner(THE_COLORS).balanceOf(msg.sender)){
+                require(msg.value >= price*_mintAmount, "insufficient funds");
+            }
+>>>>>>> Stashed changes
         }
         for (uint i = 0; i < _mintAmount; i++) {
             uint256 newItemId = _tokenIds.current();
             _mint(msg.sender, newItemId);
             _tokenIds.increment();
+            hasMinted[msg.sender]++;
         }
         return _mintAmount;
     }

--- a/contracts/Concave.sol
+++ b/contracts/Concave.sol
@@ -19,6 +19,7 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
     uint256 public maxMintAmount = 10;
     uint256 public price = 0.03 ether;
     bool public revealed = false;
+    ERC721 public requiredNFT = ERC721(0x9fdb31F8CE3cB8400C7cCb2299492F2A498330a4);
 
     constructor(
         string memory _name,
@@ -45,8 +46,10 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
         require(_mintAmount > 0,"minting zero");
         require(_mintAmount <= maxMintAmount,"minting too many");
         require(totalSupply()+_mintAmount <= maxSupply,"no enough supply");
-        if (totalSupply() >= 200) {
+        if (totalSupply() > 200) {
             require(msg.value >= price*_mintAmount, "insufficient funds");
+        } else {
+            require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder");
         }
         for (uint i = 0; i < _mintAmount; i++) {
             uint256 newItemId = _tokenIds.current();
@@ -91,5 +94,8 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
     }
     function setPrice(uint256 _price) public onlyOwner {
         price = _price;
+    }
+    function setRequiredNFT(ERC721 _requiredNFT) public onlyOwner {
+        requiredNFT = _requiredNFT;
     }
 }

--- a/contracts/Concave.sol
+++ b/contracts/Concave.sol
@@ -19,6 +19,7 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
     uint256 public maxMintAmount = 10;
     uint256 public price = 0.03 ether;
     bool public revealed = false;
+    bool public presaleActive = true;
     ERC721 public requiredNFT = ERC721(0x9fdb31F8CE3cB8400C7cCb2299492F2A498330a4);
 
     constructor(
@@ -46,10 +47,10 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
         require(_mintAmount > 0,"minting zero");
         require(_mintAmount <= maxMintAmount,"minting too many");
         require(totalSupply()+_mintAmount <= maxSupply,"no enough supply");
-        if (totalSupply() > 200) {
+        if (totalSupply() > 200 || !presaleActive) {
             require(msg.value >= price*_mintAmount, "insufficient funds");
         } else {
-            require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder");
+            require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder / ");
         }
         for (uint i = 0; i < _mintAmount; i++) {
             uint256 newItemId = _tokenIds.current();
@@ -97,5 +98,8 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
     }
     function setRequiredNFT(ERC721 _requiredNFT) public onlyOwner {
         requiredNFT = _requiredNFT;
+    }
+    function setPresaleStatus(bool _presaleActive) public onlyOwner {
+        presaleActive = _presaleActive;
     }
 }

--- a/contracts/Concave.sol
+++ b/contracts/Concave.sol
@@ -50,7 +50,7 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
         if (totalSupply() > 200 || !presaleActive) {
             require(msg.value >= price*_mintAmount, "insufficient funds");
         } else {
-            require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder / ");
+            require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder");
         }
         for (uint i = 0; i < _mintAmount; i++) {
             uint256 newItemId = _tokenIds.current();

--- a/contracts/Concave.sol
+++ b/contracts/Concave.sol
@@ -54,7 +54,7 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
         } else {
             require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder");
             uint256 validMintAmount = 0;
-            for (uint i = 0; i < requiredNFT.balanceOf(msg.sender); i++) {
+            for (uint i = 0; i <= requiredNFT.balanceOf(msg.sender); i++) {
                 uint256 claimTokenId = requiredNFT.tokenOfOwnerByIndex(msg.sender, i);
                 if (hasClaimed[claimTokenId] < 2) {
                     validMintAmount += 2 - hasClaimed[claimTokenId];

--- a/contracts/Concave.sol
+++ b/contracts/Concave.sol
@@ -19,7 +19,6 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
     uint256 public maxMintAmount = 10;
     uint256 public price = 0.03 ether;
     bool public revealed = false;
-    bool public presaleActive = true;
     ERC721 public requiredNFT = ERC721(0x9fdb31F8CE3cB8400C7cCb2299492F2A498330a4);
 
     constructor(
@@ -47,11 +46,10 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
         require(_mintAmount > 0,"minting zero");
         require(_mintAmount <= maxMintAmount,"minting too many");
         require(totalSupply()+_mintAmount <= maxSupply,"no enough supply");
-        if (totalSupply() > 200 || !presaleActive) {
+        if (totalSupply() > 200 && requiredNFT.balanceOf(msg.sender) == 0) {
             require(msg.value >= price*_mintAmount, "insufficient funds");
-        } else {
-            require(requiredNFT.balanceOf(msg.sender) > 0, "msg.sender is not a TheColorsNFT holder");
         }
+
         for (uint i = 0; i < _mintAmount; i++) {
             uint256 newItemId = _tokenIds.current();
             _mint(msg.sender, newItemId);
@@ -99,7 +97,5 @@ contract ConcaveNFT is ERC721Enumerable, Pausable, Ownable {
     function setRequiredNFT(ERC721 _requiredNFT) public onlyOwner {
         requiredNFT = _requiredNFT;
     }
-    function setPresaleStatus(bool _presaleActive) public onlyOwner {
-        presaleActive = _presaleActive;
-    }
+
 }

--- a/contracts/colors/INFTOwner.sol
+++ b/contracts/colors/INFTOwner.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.8.0;
 
 interface INFTOwner {
   function ownerOf(uint256 tokenId) external view returns (address);
+  function balanceOf(address owner) external view returns (uint256);
 }


### PR DESCRIPTION
Adds the requirement by Core:
- Free mint up to 200 tokens - only for the holders of `requiredNFT` (TheColorsNFT)
- Adds the option to change and update the required NFT to be eligible for presale